### PR TITLE
feat: add option for bearer token

### DIFF
--- a/R/HttpFileResourceGetter.R
+++ b/R/HttpFileResourceGetter.R
@@ -50,7 +50,7 @@ HttpFileResourceGetter <- R6::R6Class(
       if (!is.null(resource$identity) && nchar(resource$identity)>0 && !is.null(resource$secret) && nchar(resource$secret)>0) {
         httr::add_headers(Authorization = jsonlite::base64_enc(paste0("Basic ", resource$identity, ":", resource$secret)))
       } else if(!is.null(resource$secret) && nchar(resource$secret)>0) {
-	        httr::add_headers(Authorization = jsonlite::base64_enc(paste0("Bearer",resource$secret)))
+	httr::add_headers(Authorization = paste0("Bearer", resource$secret))
       } else {
         httr::add_headers()
       }

--- a/R/HttpFileResourceGetter.R
+++ b/R/HttpFileResourceGetter.R
@@ -50,7 +50,7 @@ HttpFileResourceGetter <- R6::R6Class(
       if (!is.null(resource$identity) && nchar(resource$identity)>0 && !is.null(resource$secret) && nchar(resource$secret)>0) {
         httr::add_headers(Authorization = jsonlite::base64_enc(paste0("Basic ", resource$identity, ":", resource$secret)))
       } else if(!is.null(resource$secret) && nchar(resource$secret)>0) {
-	httr::add_headers(Authorization = paste0("Bearer", resource$secret))
+	httr::add_headers(Authorization = paste0("Bearer ", resource$secret))
       } else {
         httr::add_headers()
       }


### PR DESCRIPTION
Motivation: then we could serve files from Armadillo. Alternatively we could add a type of resource similar to Opal and we can create a PR for that. Please advice if we are on the right track? @marikaris

N.B. not sure about the encoding step.